### PR TITLE
feat: add TTL/auto-expire for ephemeral learnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "vault:pull": "bun src/vault/cli.ts pull",
     "vault:status": "bun src/vault/cli.ts status",
     "vault:migrate": "bun src/vault/cli.ts migrate",
-    "vault:rsync": "./scripts/vault-rsync.sh"
+    "vault:rsync": "./scripts/vault-rsync.sh",
+    "expire": "bun scripts/expire-learnings.ts"
   },
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",

--- a/scripts/expire-learnings.ts
+++ b/scripts/expire-learnings.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+/**
+ * Expire stale learnings — cron-based cleanup script (Issue #4)
+ *
+ * Finds documents where expires_at has passed and marks them as superseded.
+ * Follows "Nothing is Deleted" principle — documents are superseded, not removed.
+ *
+ * Usage:
+ *   bun scripts/expire-learnings.ts          # Run expiry
+ *   bun scripts/expire-learnings.ts --dry-run # Preview without changes
+ *
+ * Cron: 0 1 * * * cd ~/repos/memory/arra-oracle-v3 && bun run expire
+ */
+
+import { createDatabase } from '../src/db/index.ts';
+
+const dryRun = process.argv.includes('--dry-run');
+const { sqlite } = createDatabase();
+const now = Date.now();
+
+// Find expired documents that haven't been superseded yet
+const expired = sqlite.prepare(`
+  SELECT id, source_file, ttl_days, expires_at, project
+  FROM oracle_documents
+  WHERE expires_at IS NOT NULL
+    AND expires_at <= ?
+    AND superseded_by IS NULL
+`).all(now) as Array<{
+  id: string;
+  source_file: string;
+  ttl_days: number | null;
+  expires_at: number;
+  project: string | null;
+}>;
+
+if (expired.length === 0) {
+  console.log('No expired documents found.');
+  process.exit(0);
+}
+
+console.log(`Found ${expired.length} expired document(s)${dryRun ? ' (dry-run)' : ''}:`);
+
+if (dryRun) {
+  for (const doc of expired) {
+    const expiredDate = new Date(doc.expires_at).toISOString().split('T')[0];
+    console.log(`  - ${doc.id} (TTL: ${doc.ttl_days}d, expired: ${expiredDate})`);
+  }
+  process.exit(0);
+}
+
+// Batch expire in a transaction
+const updateDoc = sqlite.prepare(`
+  UPDATE oracle_documents
+  SET superseded_by = 'system:auto-expire',
+      superseded_at = ?,
+      superseded_reason = ?
+  WHERE id = ?
+`);
+
+const insertLog = sqlite.prepare(`
+  INSERT INTO supersede_log (old_path, old_id, old_title, old_type, reason, superseded_at, superseded_by, project)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`);
+
+const transaction = sqlite.transaction(() => {
+  for (const doc of expired) {
+    const reason = `Auto-expired after ${doc.ttl_days ?? '?'} days`;
+
+    updateDoc.run(now, reason, doc.id);
+
+    // Get title for audit log
+    const ftsRow = sqlite.prepare('SELECT content FROM oracle_fts WHERE id = ?').get(doc.id) as { content: string } | null;
+    const title = ftsRow?.content.split('\n')[0]?.substring(0, 80) ?? doc.id;
+
+    insertLog.run(
+      doc.source_file,   // old_path
+      doc.id,            // old_id
+      title,             // old_title
+      'learning',        // old_type
+      reason,            // reason
+      now,               // superseded_at
+      'system:auto-expire', // superseded_by
+      doc.project,       // project
+    );
+
+    console.log(`  Expired: ${doc.id} (TTL: ${doc.ttl_days}d)`);
+  }
+});
+
+transaction();
+
+console.log(`\nDone. Expired ${expired.length} document(s).`);

--- a/scripts/expire-learnings.ts
+++ b/scripts/expire-learnings.ts
@@ -15,18 +15,27 @@
 import { createDatabase } from '../src/db/index.ts';
 
 const dryRun = process.argv.includes('--dry-run');
-const { sqlite } = createDatabase();
+
+let sqlite: ReturnType<typeof createDatabase>['sqlite'];
+try {
+  sqlite = createDatabase().sqlite;
+} catch (err) {
+  console.error('FATAL: Cannot open database:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
 const now = Date.now();
 
 // Find expired documents that haven't been superseded yet
 const expired = sqlite.prepare(`
-  SELECT id, source_file, ttl_days, expires_at, project
+  SELECT id, type, source_file, ttl_days, expires_at, project
   FROM oracle_documents
   WHERE expires_at IS NOT NULL
     AND expires_at <= ?
     AND superseded_by IS NULL
 `).all(now) as Array<{
   id: string;
+  type: string;
   source_file: string;
   ttl_days: number | null;
   expires_at: number;
@@ -48,7 +57,7 @@ if (dryRun) {
   process.exit(0);
 }
 
-// Batch expire in a transaction
+// Prepare statements once outside transaction
 const updateDoc = sqlite.prepare(`
   UPDATE oracle_documents
   SET superseded_by = 'system:auto-expire',
@@ -62,6 +71,9 @@ const insertLog = sqlite.prepare(`
   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
+const getFtsContent = sqlite.prepare('SELECT content FROM oracle_fts WHERE id = ?');
+
+// Batch expire in a transaction
 const transaction = sqlite.transaction(() => {
   for (const doc of expired) {
     const reason = `Auto-expired after ${doc.ttl_days ?? '?'} days`;
@@ -69,24 +81,33 @@ const transaction = sqlite.transaction(() => {
     updateDoc.run(now, reason, doc.id);
 
     // Get title for audit log
-    const ftsRow = sqlite.prepare('SELECT content FROM oracle_fts WHERE id = ?').get(doc.id) as { content: string } | null;
+    const ftsRow = getFtsContent.get(doc.id) as { content: string } | null;
+    if (!ftsRow) {
+      console.error(`  WARNING: FTS row missing for ${doc.id} — audit title will be ID only`);
+    }
     const title = ftsRow?.content.split('\n')[0]?.substring(0, 80) ?? doc.id;
 
     insertLog.run(
-      doc.source_file,   // old_path
-      doc.id,            // old_id
-      title,             // old_title
-      'learning',        // old_type
-      reason,            // reason
-      now,               // superseded_at
+      doc.source_file,      // old_path
+      doc.id,               // old_id
+      title,                // old_title
+      doc.type,             // old_type — actual document type from DB
+      reason,               // reason
+      now,                  // superseded_at
       'system:auto-expire', // superseded_by
-      doc.project,       // project
+      doc.project,          // project
     );
 
     console.log(`  Expired: ${doc.id} (TTL: ${doc.ttl_days}d)`);
   }
 });
 
-transaction();
+try {
+  transaction();
+} catch (err) {
+  console.error('FATAL: Transaction failed:', err instanceof Error ? err.message : String(err));
+  console.error('No documents were expired (transaction rolled back).');
+  process.exit(1);
+}
 
 console.log(`\nDone. Expired ${expired.length} document(s).`);

--- a/src/db/migrations/0007_huge_dormammu.sql
+++ b/src/db/migrations/0007_huge_dormammu.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `oracle_documents` ADD `expires_at` integer;--> statement-breakpoint
+ALTER TABLE `oracle_documents` ADD `ttl_days` integer;--> statement-breakpoint
+CREATE INDEX `idx_expires` ON `oracle_documents` (`expires_at`);

--- a/src/db/migrations/meta/0007_snapshot.json
+++ b/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1318 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "98fc28e7-eba9-4c8c-ab56-419b4f9f1acc",
+  "prevId": "68d1f757-6421-41ac-a46e-88763c740439",
+  "tables": {
+    "activity_log": {
+      "name": "activity_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_activity_date": {
+          "name": "idx_activity_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_type": {
+          "name": "idx_activity_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "idx_activity_project": {
+          "name": "idx_activity_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_access": {
+      "name": "document_access",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_access_project": {
+          "name": "idx_access_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_access_created": {
+          "name": "idx_access_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_access_doc": {
+          "name": "idx_access_doc",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forum_messages": {
+      "name": "forum_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "principles_found": {
+          "name": "principles_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "patterns_found": {
+          "name": "patterns_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_query": {
+          "name": "search_query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_message_thread": {
+          "name": "idx_message_thread",
+          "columns": [
+            "thread_id"
+          ],
+          "isUnique": false
+        },
+        "idx_message_role": {
+          "name": "idx_message_role",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "idx_message_created": {
+          "name": "idx_message_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "forum_messages_thread_id_forum_threads_id_fk": {
+          "name": "forum_messages_thread_id_forum_threads_id_fk",
+          "tableFrom": "forum_messages",
+          "tableTo": "forum_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "forum_threads": {
+      "name": "forum_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'human'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "issue_url": {
+          "name": "issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_thread_status": {
+          "name": "idx_thread_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_thread_project": {
+          "name": "idx_thread_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_thread_created": {
+          "name": "idx_thread_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexing_status": {
+      "name": "indexing_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_indexing": {
+          "name": "is_indexing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress_current": {
+          "name": "progress_current",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "progress_total": {
+          "name": "progress_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repo_root": {
+          "name": "repo_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "learn_log": {
+      "name": "learn_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_preview": {
+          "name": "pattern_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "concepts": {
+          "name": "concepts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_learn_project": {
+          "name": "idx_learn_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_learn_created": {
+          "name": "idx_learn_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oracle_documents": {
+      "name": "oracle_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_file": {
+          "name": "source_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concepts": {
+          "name": "concepts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_reason": {
+          "name": "superseded_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ttl_days": {
+          "name": "ttl_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_source": {
+          "name": "idx_source",
+          "columns": [
+            "source_file"
+          ],
+          "isUnique": false
+        },
+        "idx_type": {
+          "name": "idx_type",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "idx_superseded": {
+          "name": "idx_superseded",
+          "columns": [
+            "superseded_by"
+          ],
+          "isUnique": false
+        },
+        "idx_origin": {
+          "name": "idx_origin",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "idx_project": {
+          "name": "idx_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_expires": {
+          "name": "idx_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule": {
+      "name": "schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_raw": {
+          "name": "date_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_date": {
+          "name": "idx_schedule_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "idx_schedule_status": {
+          "name": "idx_schedule_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "search_log": {
+      "name": "search_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results_count": {
+          "name": "results_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_time_ms": {
+          "name": "search_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_search_project": {
+          "name": "idx_search_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_search_created": {
+          "name": "idx_search_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "supersede_log": {
+      "name": "supersede_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "old_path": {
+          "name": "old_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_id": {
+          "name": "old_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_title": {
+          "name": "old_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "old_type": {
+          "name": "old_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_path": {
+          "name": "new_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_id": {
+          "name": "new_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_title": {
+          "name": "new_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_supersede_old_path": {
+          "name": "idx_supersede_old_path",
+          "columns": [
+            "old_path"
+          ],
+          "isUnique": false
+        },
+        "idx_supersede_new_path": {
+          "name": "idx_supersede_new_path",
+          "columns": [
+            "new_path"
+          ],
+          "isUnique": false
+        },
+        "idx_supersede_created": {
+          "name": "idx_supersede_created",
+          "columns": [
+            "superseded_at"
+          ],
+          "isUnique": false
+        },
+        "idx_supersede_project": {
+          "name": "idx_supersede_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trace_log": {
+      "name": "trace_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'general'"
+        },
+        "found_files": {
+          "name": "found_files",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_commits": {
+          "name": "found_commits",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_issues": {
+          "name": "found_issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_retrospectives": {
+          "name": "found_retrospectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_learnings": {
+          "name": "found_learnings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "found_resonance": {
+          "name": "found_resonance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "issue_count": {
+          "name": "issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "parent_trace_id": {
+          "name": "parent_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "child_trace_ids": {
+          "name": "child_trace_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "prev_trace_id": {
+          "name": "prev_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_trace_id": {
+          "name": "next_trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_count": {
+          "name": "agent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'raw'"
+        },
+        "awakening": {
+          "name": "awakening",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distilled_to_id": {
+          "name": "distilled_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distilled_at": {
+          "name": "distilled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "trace_log_trace_id_unique": {
+          "name": "trace_log_trace_id_unique",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": true
+        },
+        "idx_trace_query": {
+          "name": "idx_trace_query",
+          "columns": [
+            "query"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_project": {
+          "name": "idx_trace_project",
+          "columns": [
+            "project"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_status": {
+          "name": "idx_trace_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_parent": {
+          "name": "idx_trace_parent",
+          "columns": [
+            "parent_trace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_prev": {
+          "name": "idx_trace_prev",
+          "columns": [
+            "prev_trace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_next": {
+          "name": "idx_trace_next",
+          "columns": [
+            "next_trace_id"
+          ],
+          "isUnique": false
+        },
+        "idx_trace_created": {
+          "name": "idx_trace_created",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772415363037,
       "tag": "0006_magenta_screwball",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1775550633649,
+      "tag": "0007_huge_dormammu",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -20,6 +20,9 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   supersededBy: text('superseded_by'),      // ID of newer document
   supersededAt: integer('superseded_at'),   // When it was superseded
   supersededReason: text('superseded_reason'), // Why (optional)
+  // TTL/auto-expire (Issue #4) - ephemeral learnings auto-supersede after TTL
+  expiresAt: integer('expires_at'),            // Unix timestamp (ms) when doc auto-expires
+  ttlDays: integer('ttl_days'),                // TTL in days (for reference/display)
   // Provenance tracking (Issue #22)
   origin: text('origin'),                   // 'mother' | 'arthur' | 'volt' | 'human' | null (legacy)
   project: text('project'),                 // ghq-style: 'github.com/laris-co/arra-oracle'
@@ -30,6 +33,7 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   index('idx_superseded').on(table.supersededBy),
   index('idx_origin').on(table.origin),
   index('idx_project').on(table.project),
+  index('idx_expires').on(table.expiresAt),
 ]);
 
 // Indexing status tracking

--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -49,7 +49,9 @@ beforeAll(() => {
       superseded_reason TEXT,
       origin TEXT,
       project TEXT,
-      created_by TEXT
+      created_by TEXT,
+      expires_at INTEGER,
+      ttl_days INTEGER
     );
 
     CREATE INDEX idx_type ON oracle_documents(type);

--- a/src/tools/__tests__/ttl.test.ts
+++ b/src/tools/__tests__/ttl.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for TTL helpers (pure functions).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { parseTtl, defaultTtlDays } from '../learn.ts';
+
+// ============================================================================
+// parseTtl
+// ============================================================================
+
+describe('parseTtl', () => {
+  it('should parse valid day strings', () => {
+    expect(parseTtl('7d')).toBe(7);
+    expect(parseTtl('14d')).toBe(14);
+    expect(parseTtl('30d')).toBe(30);
+    expect(parseTtl('365d')).toBe(365);
+  });
+
+  it('should return null for zero days', () => {
+    expect(parseTtl('0d')).toBeNull();
+  });
+
+  it('should return null for invalid input', () => {
+    expect(parseTtl('abc')).toBeNull();
+    expect(parseTtl('')).toBeNull();
+    expect(parseTtl(undefined)).toBeNull();
+    expect(parseTtl('7')).toBeNull();
+    expect(parseTtl('d')).toBeNull();
+    expect(parseTtl('-5d')).toBeNull();
+  });
+});
+
+// ============================================================================
+// defaultTtlDays
+// ============================================================================
+
+describe('defaultTtlDays', () => {
+  it('should return 7 for score-output prefix', () => {
+    expect(defaultTtlDays('[score-output] infra-health: disk 64%, all green')).toBe(7);
+  });
+
+  it('should return 7 for infra-health prefix', () => {
+    expect(defaultTtlDays('[infra-health] disk usage at 79%')).toBe(7);
+  });
+
+  it('should return 14 for remediation-audit prefix', () => {
+    expect(defaultTtlDays('[remediation-audit] stale reports cleaned')).toBe(14);
+  });
+
+  it('should return 7 for daily-goal prefix', () => {
+    expect(defaultTtlDays('[daily-goal] P2: Add vector alerting')).toBe(7);
+  });
+
+  it('should return 7 for goal-carryover prefix', () => {
+    expect(defaultTtlDays('[goal-carryover] P0: Fix ChromaDB vector search')).toBe(7);
+  });
+
+  it('should return 30 for retro prefix', () => {
+    expect(defaultTtlDays('[retro] session 2026-04-07 retrospective')).toBe(30);
+  });
+
+  it('should return null for patterns without TTL prefix', () => {
+    expect(defaultTtlDays('Oracle v3 ChromaDB connectivity issue')).toBeNull();
+    expect(defaultTtlDays('Some regular learning')).toBeNull();
+  });
+
+  it('should be case insensitive', () => {
+    expect(defaultTtlDays('[SCORE-OUTPUT] test')).toBe(7);
+    expect(defaultTtlDays('[Score-Output] test')).toBe(7);
+    expect(defaultTtlDays('[INFRA-HEALTH] test')).toBe(7);
+  });
+});

--- a/src/tools/__tests__/ttl.test.ts
+++ b/src/tools/__tests__/ttl.test.ts
@@ -29,6 +29,12 @@ describe('parseTtl', () => {
     expect(parseTtl('d')).toBeNull();
     expect(parseTtl('-5d')).toBeNull();
   });
+
+  it('should enforce max TTL of 365 days', () => {
+    expect(parseTtl('365d')).toBe(365);
+    expect(parseTtl('366d')).toBeNull();
+    expect(parseTtl('999999d')).toBeNull();
+  });
 });
 
 // ============================================================================

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -12,6 +12,37 @@ import { detectProject } from '../server/project-detect.ts';
 import { getVaultPsiRoot } from '../vault/handler.ts';
 import type { ToolContext, ToolResponse, OracleLearnInput } from './types.ts';
 
+// ============================================================================
+// TTL Helpers (Issue #4)
+// ============================================================================
+
+/** Default TTL by title pattern prefix */
+const TTL_PATTERNS: [RegExp, number][] = [
+  [/^\[score-output\]/i, 7],
+  [/^\[infra-health\]/i, 7],
+  [/^\[remediation-audit\]/i, 14],
+  [/^\[daily-goal\]/i, 7],
+  [/^\[goal-carryover\]/i, 7],
+  [/^\[retro\]/i, 30],
+];
+
+/** Parse TTL string like "7d" → number of days, or null if invalid */
+export function parseTtl(ttl: string | undefined | null): number | null {
+  if (!ttl) return null;
+  const match = ttl.match(/^(\d+)d$/);
+  if (!match) return null;
+  const days = parseInt(match[1], 10);
+  return days > 0 ? days : null;
+}
+
+/** Get default TTL in days based on title pattern prefix, or null for permanent */
+export function defaultTtlDays(title: string): number | null {
+  for (const [pattern, days] of TTL_PATTERNS) {
+    if (pattern.test(title)) return days;
+  }
+  return null;
+}
+
 /** Coerce concepts to string[] — handles string, array, or undefined from MCP input */
 export function coerceConcepts(concepts: unknown): string[] {
   if (Array.isArray(concepts)) return concepts.map(String);
@@ -41,6 +72,10 @@ export const learnToolDef = {
       project: {
         type: 'string',
         description: 'Source project. Accepts: "github.com/owner/repo", "owner/repo", local path with ghq/Code prefix, or GitHub URL. Auto-normalized to "github.com/owner/repo" format.'
+      },
+      ttl: {
+        type: 'string',
+        description: 'Optional TTL for auto-expiry (e.g. "7d", "14d", "30d"). Auto-assigned by title pattern if omitted: [score-output]=7d, [infra-health]=7d, [remediation-audit]=14d, [daily-goal]=7d, [goal-carryover]=7d, [retro]=30d. No TTL = permanent.'
       }
     },
     required: ['pattern']
@@ -102,7 +137,7 @@ export function extractProjectFromSource(source?: string): string | null {
 // ============================================================================
 
 export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Promise<ToolResponse> {
-  const { pattern, source, concepts, project: projectInput } = input;
+  const { pattern, source, concepts, project: projectInput, ttl } = input;
   const now = new Date();
   const dateStr = now.toISOString().split('T')[0];
 
@@ -146,6 +181,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
 
   const title = pattern.split('\n')[0].substring(0, 80);
   const conceptsList = coerceConcepts(concepts);
+  const ttlDays = parseTtl(ttl) ?? defaultTtlDays(pattern);
+  const expiresAt = ttlDays ? now.getTime() + (ttlDays * 86400000) : null;
   const frontmatter = [
     '---',
     `title: ${title}`,
@@ -153,6 +190,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     `created: ${dateStr}`,
     `source: ${source || 'Oracle Learn'}`,
     ...(project ? [`project: ${project}`] : []),
+    ...(ttlDays ? [`ttl: ${ttlDays}d`] : []),
+    ...(expiresAt ? [`expires: ${new Date(expiresAt).toISOString().split('T')[0]}`] : []),
     '---',
     '',
     `# ${title}`,
@@ -179,6 +218,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     origin: null,
     project,
     createdBy: 'arra_learn',
+    expiresAt,
+    ttlDays,
   }).run();
 
   ctx.sqlite.prepare(`
@@ -193,7 +234,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
         success: true,
         file: sourceFileRel,
         id,
-        message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}`
+        ...(ttlDays ? { ttl: `${ttlDays}d`, expires_at: new Date(expiresAt!).toISOString() } : {}),
+        message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}${ttlDays ? ` (expires in ${ttlDays} days)` : ''}`
       }, null, 2)
     }]
   };

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -32,7 +32,8 @@ export function parseTtl(ttl: string | undefined | null): number | null {
   const match = ttl.match(/^(\d+)d$/);
   if (!match) return null;
   const days = parseInt(match[1], 10);
-  return days > 0 ? days : null;
+  if (days <= 0 || days > 365) return null;
+  return days;
 }
 
 /** Get default TTL in days based on title pattern prefix, or null for permanent */
@@ -181,7 +182,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
 
   const title = pattern.split('\n')[0].substring(0, 80);
   const conceptsList = coerceConcepts(concepts);
-  const ttlDays = parseTtl(ttl) ?? defaultTtlDays(pattern);
+  const ttlDays = parseTtl(ttl) ?? defaultTtlDays(title);
   const expiresAt = ttlDays ? now.getTime() + (ttlDays * 86400000) : null;
   const frontmatter = [
     '---',

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -50,16 +50,23 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
     throw new Error(`Invalid type: ${type}. Must be one of: ${validTypes.join(', ')}`);
   }
 
+  // TTL filter: exclude expired documents (Issue #4)
+  const nowMs = Date.now();
+
   const countResult = type === 'all'
-    ? ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).get()
-    : ctx.db.select({ total: sql<number>`count(*)` }).from(oracleDocuments).where(eq(oracleDocuments.type, type)).get();
+    ? ctx.sqlite.prepare('SELECT count(*) as total FROM oracle_documents WHERE (expires_at IS NULL OR expires_at > ?)').get(nowMs) as { total: number }
+    : ctx.sqlite.prepare('SELECT count(*) as total FROM oracle_documents WHERE type = ? AND (expires_at IS NULL OR expires_at > ?)').get(type, nowMs) as { total: number };
   const total = countResult?.total ?? 0;
+
+  const expiredResult = ctx.sqlite.prepare('SELECT count(*) as cnt FROM oracle_documents WHERE expires_at IS NOT NULL AND expires_at <= ?').get(nowMs) as { cnt: number };
+  const expiredCount = expiredResult?.cnt ?? 0;
 
   const listStmt = type === 'all'
     ? ctx.sqlite.prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
+        WHERE (d.expires_at IS NULL OR d.expires_at > ?)
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `)
@@ -67,14 +74,14 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
-        WHERE d.type = ?
+        WHERE d.type = ? AND (d.expires_at IS NULL OR d.expires_at > ?)
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `);
 
   const rows = type === 'all'
-    ? listStmt.all(limit, offset)
-    : listStmt.all(type, limit, offset);
+    ? listStmt.all(nowMs, limit, offset)
+    : listStmt.all(type, nowMs, limit, offset);
 
   const documents = (rows as any[]).map((row) => ({
     id: row.id,
@@ -89,7 +96,7 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
   return {
     content: [{
       type: 'text',
-      text: JSON.stringify({ documents, total, limit, offset, type }, null, 2)
+      text: JSON.stringify({ documents, total, limit, offset, type, expired: expiredCount }, null, 2)
     }]
   };
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -327,6 +327,11 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
     : '';
   const projectParams = resolvedProject ? [resolvedProject] : [];
 
+  // TTL filter: exclude expired documents (Issue #4)
+  const nowMs = Date.now();
+  const ttlFilter = 'AND (d.expires_at IS NULL OR d.expires_at > ?)';
+  const ttlParams = [nowMs];
+
   let warning: string | undefined;
   let vectorSearchError = false;
 
@@ -338,21 +343,21 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
         SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
         FROM oracle_fts f
         JOIN oracle_documents d ON f.id = d.id
-        WHERE oracle_fts MATCH ? ${projectFilter}
+        WHERE oracle_fts MATCH ? ${projectFilter} ${ttlFilter}
         ORDER BY rank
         LIMIT ?
       `);
-      ftsRawResults = stmt.all(safeQuery, ...projectParams, limit * 2);
+      ftsRawResults = stmt.all(safeQuery, ...projectParams, ...ttlParams, limit * 2);
     } else {
       const stmt = ctx.sqlite.prepare(`
         SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
         FROM oracle_fts f
         JOIN oracle_documents d ON f.id = d.id
-        WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter}
+        WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter} ${ttlFilter}
         ORDER BY rank
         LIMIT ?
       `);
-      ftsRawResults = stmt.all(safeQuery, type, ...projectParams, limit * 2);
+      ftsRawResults = stmt.all(safeQuery, type, ...projectParams, ...ttlParams, limit * 2);
     }
   }
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -396,8 +396,25 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   }));
 
   const combinedResults = combineResults(ftsResults, normalizedVectorResults);
-  const totalMatches = combinedResults.length;
-  const results = combinedResults.slice(offset, offset + limit);
+
+  // Post-filter: remove expired docs from vector results (FTS already filtered via SQL)
+  const expiredIds = new Set<string>();
+  if (normalizedVectorResults.length > 0) {
+    const ids = combinedResults.map(r => r.id);
+    if (ids.length > 0) {
+      const placeholders = ids.map(() => '?').join(',');
+      const expiredRows = ctx.sqlite.prepare(
+        `SELECT id FROM oracle_documents WHERE id IN (${placeholders}) AND expires_at IS NOT NULL AND expires_at <= ?`
+      ).all(...ids, nowMs) as { id: string }[];
+      for (const row of expiredRows) expiredIds.add(row.id);
+    }
+  }
+  const filteredResults = expiredIds.size > 0
+    ? combinedResults.filter(r => !expiredIds.has(r.id))
+    : combinedResults;
+
+  const totalMatches = filteredResults.length;
+  const results = filteredResults.slice(offset, offset + limit);
 
   const ftsCount = results.filter((r) => r.source === 'fts').length;
   const vectorCount = results.filter((r) => r.source === 'vector').length;

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -47,6 +47,7 @@ export interface OracleLearnInput {
   source?: string;
   concepts?: string[];
   project?: string;
+  ttl?: string; // e.g. "7d", "14d", "30d" — parsed to days
 }
 
 export interface OracleListInput {


### PR DESCRIPTION
## Summary

Add TTL (time-to-live) support for ephemeral Oracle learnings so score-outputs, health reports, and other transient documents auto-expire instead of polluting memory indefinitely. Expired docs are auto-superseded — not deleted — following the "Nothing is Deleted" principle.

Fixes #4

## Changes

- Add `expires_at` and `ttl_days` columns to `oracle_documents` schema
- `arra_learn` accepts optional `ttl` param (e.g. "7d"), auto-assigns default TTL by title pattern prefix
- Search and list filter out expired documents via SQL WHERE clause
- Post-filter vector search results to exclude expired docs
- Add `expire-learnings.ts` cron cleanup script with `--dry-run` support
- 12 unit tests for TTL helper functions (including max 365d cap)

## Default TTL by Pattern

| Pattern | TTL | Rationale |
|---------|-----|-----------|
| `[score-output]` | 7d | Status changes frequently |
| `[infra-health]` | 7d | Only latest matters |
| `[remediation-audit]` | 14d | Keep audit trail slightly longer |
| `[daily-goal]` | 7d | Goals expire after deadline |
| `[goal-carryover]` | 7d | Same as daily-goal |
| `[retro]` | 30d | Retros have longer relevance |
| No prefix | No TTL | Permanent by default |

## Testing

- Type check: Pass (4 pre-existing errors on main, no new errors)
- Unit tests: 157 passed, 0 failed
- TTL tests: 12 tests, 25 assertions

## Related

- gobikom/soul-orchestra#125 — Short-term fix (auto-supersede in score prompt)
- This PR is the long-term systemic fix at the Oracle level