### PR TITLE
feat: exclude superseded docs from search by default

### DIFF
--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -50,23 +50,27 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
     throw new Error(`Invalid type: ${type}. Must be one of: ${validTypes.join(', ')}`);
   }
 
-  // TTL filter: exclude expired documents (Issue #4)
+  // TTL + supersede filters (Issue #4, #7)
   const nowMs = Date.now();
+  const activeFilter = '(expires_at IS NULL OR expires_at > ?) AND superseded_by IS NULL';
 
   const countResult = type === 'all'
-    ? ctx.sqlite.prepare('SELECT count(*) as total FROM oracle_documents WHERE (expires_at IS NULL OR expires_at > ?)').get(nowMs) as { total: number }
-    : ctx.sqlite.prepare('SELECT count(*) as total FROM oracle_documents WHERE type = ? AND (expires_at IS NULL OR expires_at > ?)').get(type, nowMs) as { total: number };
+    ? ctx.sqlite.prepare(`SELECT count(*) as total FROM oracle_documents WHERE ${activeFilter}`).get(nowMs) as { total: number }
+    : ctx.sqlite.prepare(`SELECT count(*) as total FROM oracle_documents WHERE type = ? AND ${activeFilter}`).get(type, nowMs) as { total: number };
   const total = countResult?.total ?? 0;
 
   const expiredResult = ctx.sqlite.prepare('SELECT count(*) as cnt FROM oracle_documents WHERE expires_at IS NOT NULL AND expires_at <= ?').get(nowMs) as { cnt: number };
   const expiredCount = expiredResult?.cnt ?? 0;
+
+  const supersededResult = ctx.sqlite.prepare('SELECT count(*) as cnt FROM oracle_documents WHERE superseded_by IS NOT NULL').get() as { cnt: number };
+  const supersededCount = supersededResult?.cnt ?? 0;
 
   const listStmt = type === 'all'
     ? ctx.sqlite.prepare(`
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
-        WHERE (d.expires_at IS NULL OR d.expires_at > ?)
+        WHERE (d.expires_at IS NULL OR d.expires_at > ?) AND d.superseded_by IS NULL
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `)
@@ -74,7 +78,7 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
         SELECT d.id, d.type, d.source_file, d.concepts, d.indexed_at, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
-        WHERE d.type = ? AND (d.expires_at IS NULL OR d.expires_at > ?)
+        WHERE d.type = ? AND (d.expires_at IS NULL OR d.expires_at > ?) AND d.superseded_by IS NULL
         ORDER BY d.indexed_at DESC
         LIMIT ? OFFSET ?
       `);
@@ -96,7 +100,7 @@ export async function handleList(ctx: ToolContext, input: OracleListInput): Prom
   return {
     content: [{
       type: 'text',
-      text: JSON.stringify({ documents, total, limit, offset, type, expired: expiredCount }, null, 2)
+      text: JSON.stringify({ documents, total, limit, offset, type, expired: expiredCount, superseded: supersededCount }, null, 2)
     }]
   };
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -55,6 +55,11 @@ export const searchToolDef = {
         type: 'string',
         enum: ['nomic', 'qwen3', 'bge-m3'],
         description: 'Embedding model: bge-m3 (default, multilingual Thai↔EN, 1024-dim), nomic (fast, 768-dim), or qwen3 (cross-language, 4096-dim)',
+      },
+      include_superseded: {
+        type: 'boolean',
+        description: 'Include superseded documents in results (default: false). Set true for audit trail or history review.',
+        default: false
       }
     },
     required: ['query']
@@ -309,7 +314,7 @@ export function combineResults(
 
 export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): Promise<ToolResponse> {
   const startTime = Date.now();
-  const { query, type = 'all', limit = 5, offset = 0, mode = 'hybrid', project, cwd, model } = input;
+  const { query, type = 'all', limit = 5, offset = 0, mode = 'hybrid', project, cwd, model, include_superseded = false } = input;
 
   if (!query || query.trim().length === 0) {
     throw new Error('Query cannot be empty');
@@ -332,6 +337,10 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   const ttlFilter = 'AND (d.expires_at IS NULL OR d.expires_at > ?)';
   const ttlParams = [nowMs];
 
+  // Supersede filter: exclude superseded documents by default (Issue #7)
+  const supersedeFilter = include_superseded ? '' : 'AND d.superseded_by IS NULL';
+
+
   let warning: string | undefined;
   let vectorSearchError = false;
 
@@ -343,7 +352,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
         SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
         FROM oracle_fts f
         JOIN oracle_documents d ON f.id = d.id
-        WHERE oracle_fts MATCH ? ${projectFilter} ${ttlFilter}
+        WHERE oracle_fts MATCH ? ${projectFilter} ${ttlFilter} ${supersedeFilter}
         ORDER BY rank
         LIMIT ?
       `);
@@ -353,7 +362,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
         SELECT f.id, f.content, d.type, d.source_file, d.concepts, rank
         FROM oracle_fts f
         JOIN oracle_documents d ON f.id = d.id
-        WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter} ${ttlFilter}
+        WHERE oracle_fts MATCH ? AND d.type = ? ${projectFilter} ${ttlFilter} ${supersedeFilter}
         ORDER BY rank
         LIMIT ?
       `);
@@ -397,20 +406,25 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   const combinedResults = combineResults(ftsResults, normalizedVectorResults);
 
-  // Post-filter: remove expired docs from vector results (FTS already filtered via SQL)
-  const expiredIds = new Set<string>();
+  // Post-filter: remove expired + superseded docs from vector results (FTS already filtered via SQL)
+  const excludeIds = new Set<string>();
   if (normalizedVectorResults.length > 0) {
     const ids = combinedResults.map(r => r.id);
     if (ids.length > 0) {
       const placeholders = ids.map(() => '?').join(',');
-      const expiredRows = ctx.sqlite.prepare(
-        `SELECT id FROM oracle_documents WHERE id IN (${placeholders}) AND expires_at IS NOT NULL AND expires_at <= ?`
-      ).all(...ids, nowMs) as { id: string }[];
-      for (const row of expiredRows) expiredIds.add(row.id);
+      const conditions = ['(expires_at IS NOT NULL AND expires_at <= ?)'];
+      const params: any[] = [...ids, nowMs];
+      if (!include_superseded) {
+        conditions.push('(superseded_by IS NOT NULL)');
+      }
+      const excludeRows = ctx.sqlite.prepare(
+        `SELECT id FROM oracle_documents WHERE id IN (${placeholders}) AND (${conditions.join(' OR ')})`
+      ).all(...params) as { id: string }[];
+      for (const row of excludeRows) excludeIds.add(row.id);
     }
   }
-  const filteredResults = expiredIds.size > 0
-    ? combinedResults.filter(r => !expiredIds.has(r.id))
+  const filteredResults = excludeIds.size > 0
+    ? combinedResults.filter(r => !excludeIds.has(r.id))
     : combinedResults;
 
   const totalMatches = filteredResults.length;

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -38,6 +38,7 @@ export interface OracleSearchInput {
   project?: string;
   cwd?: string;
   model?: 'nomic' | 'qwen3' | 'bge-m3';
+  include_superseded?: boolean; // default false — set true for audit trail
 }
 
 export interface OracleReflectInput {}


### PR DESCRIPTION
## Summary

Superseded documents are now excluded from `arra_search` and `arra_list` results by default. Use `include_superseded=true` for audit trail access.

Fixes #7

## Changes

- `arra_search`: new `include_superseded` param (default: false)
  - FTS queries add `AND d.superseded_by IS NULL`
  - Vector post-filter also excludes superseded docs
- `arra_list`: always excludes superseded, shows superseded count in metadata
- `OracleSearchInput`: new `include_superseded?: boolean` field

## Testing

- Type check: Pass (no new errors)
- Unit tests: 157 passed, 0 failed
- Same filter pattern as TTL (#4) — proven approach