### PR TITLE
fix: remove hardcoded ChromaDB paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import type { VectorStoreAdapter } from './vector/types.ts';
 import path from 'path';
 import fs from 'fs';
 import { loadToolGroupConfig, getDisabledTools, type ToolGroupConfig } from './config/tool-groups.ts';
-import { ORACLE_DATA_DIR, DB_PATH, CHROMADB_DIR } from './config.ts';
+import { ORACLE_DATA_DIR, DB_PATH } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 
 // Tool handlers (all extracted to src/tools/)
@@ -98,9 +98,8 @@ class OracleMCPServer {
       console.error(`[ToolGroups] Disabled: ${disabledGroups.join(', ')}`);
     }
 
-    this.vectorStore = createVectorStore({
-      dataPath: CHROMADB_DIR,
-    });
+    // Use factory defaults from env vars (ORACLE_VECTOR_DB, ORACLE_EMBEDDING_PROVIDER)
+    this.vectorStore = createVectorStore();
 
     const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', 'package.json'), 'utf-8'));
     this.version = pkg.version;

--- a/src/indexer/cli.ts
+++ b/src/indexer/cli.ts
@@ -4,7 +4,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { DB_PATH, CHROMADB_DIR } from '../config.ts';
+import { DB_PATH } from '../config.ts';
 import { getVaultPsiRoot } from '../vault/handler.ts';
 import type { IndexerConfig } from '../types.ts';
 import { OracleIndexer } from './index.ts';
@@ -28,7 +28,6 @@ const repoRoot = process.env.ORACLE_REPO_ROOT ||
 const config: IndexerConfig = {
   repoRoot,
   dbPath: DB_PATH,
-  chromaPath: CHROMADB_DIR,
   sourcePaths: {
     resonance: '\u03c8/memory/resonance',
     learnings: '\u03c8/memory/learnings',

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -80,7 +80,8 @@ export class OracleIndexer {
 
     // Initialize vector store
     try {
-      this.vectorClient = createVectorStore({ dataPath: this.config.chromaPath });
+      // Use factory defaults from env vars (ORACLE_VECTOR_DB, ORACLE_EMBEDDING_PROVIDER)
+      this.vectorClient = createVectorStore();
       await this.vectorClient.connect();
       await this.vectorClient.deleteCollection();
       await this.vectorClient.ensureCollection();

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,6 @@ export interface HybridSearchOptions {
 export interface IndexerConfig {
   repoRoot: string;
   dbPath: string;
-  chromaPath: string;
   sourcePaths: {
     resonance: string;
     learnings: string;


### PR DESCRIPTION
## Summary

Remove hardcoded `CHROMADB_DIR` from MCP server and indexer. Both now use `createVectorStore()` with no args, which reads `ORACLE_VECTOR_DB` from env vars (default: lancedb, prod: qdrant).

Fixes #3

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Remove `CHROMADB_DIR` import, call `createVectorStore()` with no args |
| `src/indexer/index.ts` | Remove `config.chromaPath`, use factory defaults |
| `src/indexer/cli.ts` | Remove `CHROMADB_DIR` import and config field |
| `src/types.ts` | Remove `chromaPath` from `IndexerConfig` |

## Testing

- Type check: Pass
- Unit tests: 157 passed, 0 failed