### PR TITLE
fix(server): bind HTTP to 127.0.0.1 by default (#12, Stage 1)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,11 @@ export const CHROMADB_DIR = path.join(HOME_DIR, C.CHROMADB_DIR_NAME);
 // If empty, /mcp will reject all requests with 401 (fail-safe)
 export const MCP_AUTH_TOKEN = process.env.MCP_AUTH_TOKEN || '';
 
+// HTTP bind host. Defaults to 127.0.0.1 so the server is reachable only via
+// localhost / a reverse proxy; set ORACLE_BIND_HOST=0.0.0.0 to bind all
+// interfaces (only safe when auth is enforced on every /api/* route).
+export const ORACLE_BIND_HOST = process.env.ORACLE_BIND_HOST || '127.0.0.1';
+
 // OAuth 2.1 — PIN-based auth for Claude Desktop / claude.ai Custom Connectors
 // If MCP_OAUTH_PIN is empty, OAuth routes are not mounted (Bearer-only mode)
 export const MCP_OAUTH_PIN = process.env.MCP_OAUTH_PIN || '';

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,11 +53,8 @@ export const MCP_AUTH_TOKEN = process.env.MCP_AUTH_TOKEN || '';
 // current edge gate; binding non-loopback bypasses it entirely.
 export const ORACLE_BIND_HOST = (process.env.ORACLE_BIND_HOST || '').trim() || '127.0.0.1';
 
-if (
-  ORACLE_BIND_HOST !== '127.0.0.1'
-  && ORACLE_BIND_HOST !== 'localhost'
-  && ORACLE_BIND_HOST !== '::1'
-) {
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '::ffff:127.0.0.1']);
+if (!LOOPBACK_HOSTS.has(ORACLE_BIND_HOST)) {
   console.warn(
     `⚠️  SECURITY: ORACLE_BIND_HOST=${ORACLE_BIND_HOST} binds non-loopback. `
     + `/api/* routes are still unauthenticated until issue #12 Stage 2 lands — server is exposed.`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,9 +45,24 @@ export const CHROMADB_DIR = path.join(HOME_DIR, C.CHROMADB_DIR_NAME);
 export const MCP_AUTH_TOKEN = process.env.MCP_AUTH_TOKEN || '';
 
 // HTTP bind host. Defaults to 127.0.0.1 so the server is reachable only via
-// localhost / a reverse proxy; set ORACLE_BIND_HOST=0.0.0.0 to bind all
-// interfaces (only safe when auth is enforced on every /api/* route).
-export const ORACLE_BIND_HOST = process.env.ORACLE_BIND_HOST || '127.0.0.1';
+// localhost / a reverse proxy.
+//
+// WARNING: /api/* routes are currently UNAUTHENTICATED (issue #12 Stage 2
+// pending — auth middleware not yet shipped). Do NOT set ORACLE_BIND_HOST to
+// 0.0.0.0 until that lands. The reverse proxy (nginx basic_auth) is the only
+// current edge gate; binding non-loopback bypasses it entirely.
+export const ORACLE_BIND_HOST = (process.env.ORACLE_BIND_HOST || '').trim() || '127.0.0.1';
+
+if (
+  ORACLE_BIND_HOST !== '127.0.0.1'
+  && ORACLE_BIND_HOST !== 'localhost'
+  && ORACLE_BIND_HOST !== '::1'
+) {
+  console.warn(
+    `⚠️  SECURITY: ORACLE_BIND_HOST=${ORACLE_BIND_HOST} binds non-loopback. `
+    + `/api/* routes are still unauthenticated until issue #12 Stage 2 lands — server is exposed.`,
+  );
+}
 
 // OAuth 2.1 — PIN-based auth for Claude Desktop / claude.ai Custom Connectors
 // If MCP_OAUTH_PIN is empty, OAuth routes are not mounted (Bearer-only mode)

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import {
   performGracefulShutdown,
 } from './process-manager/index.ts';
 
-import { PORT, ORACLE_DATA_DIR, MCP_AUTH_TOKEN, MCP_OAUTH_PIN, MCP_EXTERNAL_URL } from './config.ts';
+import { PORT, ORACLE_BIND_HOST, ORACLE_DATA_DIR, MCP_AUTH_TOKEN, MCP_OAUTH_PIN, MCP_EXTERNAL_URL } from './config.ts';
 import { db, closeDb, indexingStatus } from './db/index.ts';
 
 // Route modules
@@ -177,7 +177,7 @@ app.all('/mcp', async (c) => {
 console.log(`
 🔮 Arra Oracle HTTP Server running! (Hono.js)
 
-   URL: http://localhost:${PORT}
+   Bind: ${ORACLE_BIND_HOST}:${PORT}
 
    Endpoints:
    - GET  /api/health          Health check
@@ -214,5 +214,6 @@ if (MCP_OAUTH_PIN) {
 
 export default {
   port: Number(PORT),
+  hostname: ORACLE_BIND_HOST,
   fetch: app.fetch,
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -177,7 +177,7 @@ app.all('/mcp', async (c) => {
 console.log(`
 🔮 Arra Oracle HTTP Server running! (Hono.js)
 
-   Bind: http://${ORACLE_BIND_HOST}:${PORT}
+   Bind: http://${ORACLE_BIND_HOST.includes(':') ? `[${ORACLE_BIND_HOST}]` : ORACLE_BIND_HOST}:${PORT}
 
    Endpoints:
    - GET  /api/health          Health check

--- a/src/server.ts
+++ b/src/server.ts
@@ -177,7 +177,7 @@ app.all('/mcp', async (c) => {
 console.log(`
 🔮 Arra Oracle HTTP Server running! (Hono.js)
 
-   Bind: ${ORACLE_BIND_HOST}:${PORT}
+   Bind: http://${ORACLE_BIND_HOST}:${PORT}
 
    Endpoints:
    - GET  /api/health          Health check


### PR DESCRIPTION
## Summary
- `src/server.ts` default export now sets `hostname: ORACLE_BIND_HOST` (default `127.0.0.1`)
- New `ORACLE_BIND_HOST` env in `src/config.ts` for operators who need LAN bind

## Why
Partial fix for #12 — Stage 1 of the coordinated containment. Bun.serve was binding `0.0.0.0` by default, which combined with the missing auth on `/api/*` exposed private agent scopes to any network peer with port reachability.

Surfaced during multi-agent security review of gobikom/my-ai-soul-mcp#49, where the new `unified_search` tool normalized `/api/search` as the canonical cross-store channel — amplifying the existing gap into a load-bearing one.

## Stage 0 — already live (nginx containment)
The exfil path via `oracle.goko.digital` was closed in nginx by adding `auth_basic` to the vhost (same htpasswd as `dashboard.goko.digital`). Unauth requests now return 401 at the edge. This PR is the code-side companion so Oracle itself no longer listens on external interfaces even if nginx is misconfigured or bypassed.

## Test plan
- [ ] Bun restart → verify `ss -tlnp | grep 47778` shows `127.0.0.1:47778` (not `*:47778`)
- [ ] `curl http://127.0.0.1:47778/api/health` → 200 (local still works)
- [ ] `curl https://oracle.goko.digital/api/health` via nginx with basic auth → 200
- [ ] `curl https://oracle.goko.digital/api/health` without basic auth → 401
- [ ] soul-mcp `unified_search` still green (calls `http://127.0.0.1:47778` — unaffected)
- [ ] auto-ops Oracle vector probe still green (same loopback URL)

## Follow-ups (tracked in #12)
- Stage 2: `src/middleware/api-auth.ts` with optional-enforce bearer token → flip to required after all clients coordinated
- Clients to update before flip: `my-ai-soul-mcp::_fetch_oracle_results`, `auto-ops::watchdog.py::probe_oracle_vector`, `arra-oracle-skills::schedule/query.ts`
- Secrets will land in `~/.secrets/oracle-api.env`

Refs: #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)