### PR TITLE
feat(server): /api/* required-enforce — fail at startup if token missing (#12 Stage 2C)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,8 +70,10 @@ export const ORACLE_BIND_HOST = (process.env.ORACLE_BIND_HOST || '').trim() || '
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '::ffff:127.0.0.1']);
 if (!LOOPBACK_HOSTS.has(ORACLE_BIND_HOST)) {
   console.warn(
-    `⚠️  SECURITY: ORACLE_BIND_HOST=${ORACLE_BIND_HOST} binds non-loopback. `
-    + `/api/* routes are still unauthenticated until issue #12 Stage 2 lands — server is exposed.`,
+    `⚠️  ORACLE_BIND_HOST=${ORACLE_BIND_HOST} binds non-loopback. `
+    + `/api/* is gated by Bearer token (issue #12 Stage 2 complete), but exposing the port `
+    + `widens the attack surface for credential theft / brute-force attempts. Keep loopback `
+    + `unless you have a specific reason and have audited the additional risk.`,
   );
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,16 +44,16 @@ export const CHROMADB_DIR = path.join(HOME_DIR, C.CHROMADB_DIR_NAME);
 // If empty, /mcp will reject all requests with 401 (fail-safe)
 export const MCP_AUTH_TOKEN = process.env.MCP_AUTH_TOKEN || '';
 
-// /api/* Bearer token (issue #12 Stage 2). Optional-enforce: if empty, the
-// api-auth middleware allows all /api/* requests through (backward-compat
-// deployment window). When set, every /api/* request except /api/health
-// must carry `Authorization: Bearer <token>` matching exactly.
+// /api/* Bearer token (issue #12 Stage 2 — required-enforce). Every /api/*
+// request except /api/health must carry `Authorization: Bearer <token>`
+// matching exactly. The api-auth middleware throws at startup if this is
+// empty — Oracle will fail to boot on misconfigured environments rather
+// than silently allowing unauthenticated traffic.
 //
 // Provisioned via ~/.secrets/oracle-api.env (mode 600), loaded by systemd
-// EnvironmentFile. See issue #12 for the rollout sequence: deploy this PR
-// first (no clients sending tokens, env unset → no impact), then update
-// clients to send the header, then a follow-up PR flips the middleware
-// from optional-enforce to required-enforce.
+// EnvironmentFile. The same secrets file is shared with all clients
+// (psak-soul-mcp, auto-ops watchdog, arra-oracle-skills) so rotations
+// happen in one place.
 export const ORACLE_API_TOKEN = (process.env.ORACLE_API_TOKEN || '').trim();
 
 // HTTP bind host. Defaults to 127.0.0.1 so the server is reachable only via

--- a/src/middleware/api-auth.test.ts
+++ b/src/middleware/api-auth.test.ts
@@ -26,24 +26,13 @@ function buildApp(token: string) {
   return app;
 }
 
-describe('createApiAuthMiddleware — compat mode (token unset)', () => {
-  it('allows /api/* with no Authorization header', async () => {
-    const app = buildApp('');
-    const res = await app.request('/api/search');
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, route: 'search' });
+describe('createApiAuthMiddleware — startup validation', () => {
+  it('throws when token is empty string', () => {
+    expect(() => createApiAuthMiddleware('')).toThrow(/ORACLE_API_TOKEN is required/);
   });
 
-  it('treats whitespace-only token as compat mode', async () => {
-    const app = buildApp('   ');
-    const res = await app.request('/api/search');
-    expect(res.status).toBe(200);
-  });
-
-  it('still allows /api/health without Authorization', async () => {
-    const app = buildApp('');
-    const res = await app.request('/api/health');
-    expect(res.status).toBe(200);
+  it('throws when token is whitespace-only', () => {
+    expect(() => createApiAuthMiddleware('   ')).toThrow(/ORACLE_API_TOKEN is required/);
   });
 });
 

--- a/src/middleware/api-auth.ts
+++ b/src/middleware/api-auth.ts
@@ -12,11 +12,12 @@
  *   middleware. Tests inject a token directly; production wires
  *   `ORACLE_API_TOKEN` from config at startup. This avoids module-cache
  *   gymnastics in test isolation.
- * - **Optional-enforce**: if the configured token is empty, the middleware
- *   ALLOWS all requests through (backward-compat deployment window for
- *   issue #12 Stage 2 rollout). When the token is set, every gated request
- *   must carry `Authorization: Bearer <token>` matching exactly. A
- *   follow-up PR will retire optional-enforce after all clients ship.
+ * - **Required-enforce**: the factory throws at startup if the token is
+ *   empty. Every gated request must carry `Authorization: Bearer <token>`
+ *   matching exactly. There is no compat path — issue #12 Stage 2 rollout
+ *   is complete (clients ship the header, server enforces). Misconfigured
+ *   environments fail loudly at startup rather than silently allowing
+ *   unauthenticated traffic through.
  * - The path `/api/health` is always exempted so liveness probes
  *   (auto-ops watchdog, k8s-style monitors) keep working with no special
  *   config.
@@ -41,6 +42,15 @@ const HEALTH_PATH = '/api/health';
 const BEARER_PREFIX = 'Bearer ';
 
 export function createApiAuthMiddleware(token: string): MiddlewareHandler {
+  const configuredToken = token.trim();
+  if (!configuredToken) {
+    throw new Error(
+      'createApiAuthMiddleware: ORACLE_API_TOKEN is required (issue #12 Stage 2 '
+      + 'flip-default complete, no compat path). Provision via '
+      + '~/.secrets/oracle-api.env and wire into systemd EnvironmentFile.',
+    );
+  }
+
   // Per-process random key. Used only to normalise comparison inputs to
   // equal length via HMAC-SHA256 before timingSafeEqual sees them. Defeats
   // the length-leak side channel in raw timingSafeEqual (which throws on
@@ -53,8 +63,6 @@ export function createApiAuthMiddleware(token: string): MiddlewareHandler {
     return timingSafeEqual(ah, bh);
   }
 
-  const configuredToken = token.trim();
-
   return async (c, next) => {
     // CORS preflight always passes. Browsers send OPTIONS without an
     // Authorization header to discover allowed methods/headers; blocking
@@ -63,14 +71,8 @@ export function createApiAuthMiddleware(token: string): MiddlewareHandler {
       return next();
     }
 
-    // Health probe always exempt regardless of enforcement state.
+    // Health probe always exempt so liveness checks keep working.
     if (c.req.path === HEALTH_PATH) {
-      return next();
-    }
-
-    // Optional-enforce: no token configured → allow (compat deployment
-    // window). When the token is provisioned in env, this branch goes away.
-    if (!configuredToken) {
       return next();
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -212,7 +212,7 @@ console.log(`
    - ALL /mcp                  Streamable HTTP MCP endpoint
 `);
 console.log(MCP_AUTH_TOKEN ? '   🔑 MCP auth: Bearer token configured' : '   ⚠️  MCP auth: Bearer token NOT configured');
-console.log(ORACLE_API_TOKEN ? '   🔑 /api/* auth: Bearer token enforced (ORACLE_API_TOKEN set)' : '   ⚠️  /api/* auth: open (ORACLE_API_TOKEN not set — issue #12 Stage 2 deployment window)');
+console.log('   🔑 /api/* auth: Bearer token required (issue #12 Stage 2 complete)');
 console.log('   ℹ️  /api/health: always exempt (liveness probes unaffected); OPTIONS preflight always exempt');
 if (MCP_OAUTH_PIN) {
   console.log(`   🔐 OAuth 2.1: enabled (${MCP_EXTERNAL_URL})`);


### PR DESCRIPTION
Closes #12. Removes the optional-enforce compat branch from PR #18 — middleware now throws at startup if ORACLE_API_TOKEN is empty. Fail-safe by default.

All 3 clients (my-ai-soul-mcp #51, auto-ops #20, arra-oracle-skills #1+#2) shipped and ORACLE_API_TOKEN is provisioned in production via systemd EnvironmentFile pointing at ~/.secrets/oracle-api.env. Verified loopback + nginx end-to-end before opening this PR.

## Test plan
- [x] 13 unit tests pass (replaced 3 compat-mode tests with 2 startup-validation tests)
- [x] Manual: loopback /api no-token → 401, +token → 200, /api/health → 200
- [x] Manual: nginx /api +token → 200, basic_auth on / still works
- [x] Manual: soul-mcp + auto-ops + oracle-skills all green with enforcement on (verified during Sprint 4 deploy)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)