### PR TITLE
fix(test): wire Bearer auth into http.test.ts integration suite (#20)

### DIFF
--- a/src/integration/http.test.ts
+++ b/src/integration/http.test.ts
@@ -12,7 +12,11 @@ const BASE_URL = "http://localhost:47778";
 // dev without oracle-v3 running).  Either way, the spawned server receives the
 // same value via the `env` block in beforeAll, so token and server always agree.
 const TEST_TOKEN = process.env.ORACLE_API_TOKEN ?? "integration-test-token";
-process.env.ORACLE_API_TOKEN = TEST_TOKEN;
+// NOTE: process.env.ORACLE_API_TOKEN mutation removed — the env: block in
+// beforeAll is the authoritative mechanism for passing the token to the spawned
+// server process.  Mutating process.env at module scope is a no-op when the
+// suite reuses an existing server and causes silent 401s when that server's
+// token differs from TEST_TOKEN.
 
 let serverProcess: Subprocess | null = null;
 
@@ -22,13 +26,20 @@ let serverProcess: Subprocess | null = null;
  * than sprinkling headers at every call site.
  */
 async function authFetch(url: string, init?: RequestInit): Promise<Response> {
-  return fetch(url, {
-    ...init,
-    headers: {
-      ...init?.headers,
-      Authorization: `Bearer ${TEST_TOKEN}`,
-    },
-  });
+  try {
+    return await fetch(url, {
+      ...init,
+      headers: {
+        // Normalise to plain object so spread works for all init.headers shapes
+        // (Headers instance, [string, string][], or plain object).
+        ...Object.fromEntries(new Headers(init?.headers ?? {})),
+        Authorization: `Bearer ${TEST_TOKEN}`,
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`authFetch failed for ${url}: ${message}`);
+  }
 }
 
 async function waitForServer(maxAttempts = 30): Promise<boolean> {
@@ -79,9 +90,9 @@ describe("HTTP API Integration", () => {
         try {
           const { value } = await reader.read();
           if (value) stderr = new TextDecoder().decode(value);
-        } catch { /* ignore */ }
+        } catch (readErr) { stderr = `(could not read stderr: ${readErr})`; }
       }
-      throw new Error(`Server failed to start within 15 seconds.\nServer stderr: ${stderr}`);
+      throw new Error(`Server failed to start within ${30 * 500 / 1000} seconds.\nServer stderr: ${stderr}`);
     }
     console.log("Server ready");
   }, 30_000);
@@ -104,9 +115,23 @@ describe("HTTP API Integration", () => {
       expect(data.status).toBe("ok");
     });
 
+    test("GET /api/health is exempt from auth (wrong token still returns ok)", async () => {
+      const res = await fetch(`${BASE_URL}/api/health`, {
+        headers: { Authorization: "Bearer wrong-token-intentionally-invalid" },
+      });
+      expect(res.ok).toBe(true);
+      const data = await res.json();
+      expect(data.status).toBe("ok");
+    });
+
+    test("GET /api/stats without auth returns 401", async () => {
+      const res = await fetch(`${BASE_URL}/api/stats`);
+      expect(res.status).toBe(401);
+    });
+
     test("GET /api/stats returns statistics", async () => {
       const res = await authFetch(`${BASE_URL}/api/stats`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(typeof data.total).toBe("number");
     }, 15_000);
@@ -119,21 +144,21 @@ describe("HTTP API Integration", () => {
   describe("Search", () => {
     test("GET /api/search with query returns results", async () => {
       const res = await authFetch(`${BASE_URL}/api/search?q=oracle`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     }, 30_000);
 
     test("GET /api/search with type filter", async () => {
       const res = await authFetch(`${BASE_URL}/api/search?q=test&type=learning`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     }, 30_000);
 
     test("GET /api/search with limit and offset", async () => {
       const res = await authFetch(`${BASE_URL}/api/search?q=test&limit=5&offset=0`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(data.results.length).toBeLessThanOrEqual(5);
     }, 30_000);
@@ -151,21 +176,21 @@ describe("HTTP API Integration", () => {
   describe("List & Browse", () => {
     test("GET /api/list returns documents", async () => {
       const res = await authFetch(`${BASE_URL}/api/list`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     });
 
     test("GET /api/list with type filter", async () => {
       const res = await authFetch(`${BASE_URL}/api/list?type=principle`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     });
 
     test("GET /api/list with pagination", async () => {
       const res = await authFetch(`${BASE_URL}/api/list?limit=10&offset=0`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(data.results.length).toBeLessThanOrEqual(10);
     });
@@ -177,7 +202,7 @@ describe("HTTP API Integration", () => {
   describe("Reflect", () => {
     test("GET /api/reflect returns response", async () => {
       const res = await authFetch(`${BASE_URL}/api/reflect`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       // Empty DB returns { error: "No documents found" }, populated returns { content: ... }
       expect(data).toHaveProperty(data.content ? "content" : "error");
@@ -190,21 +215,22 @@ describe("HTTP API Integration", () => {
   describe("Dashboard", () => {
     test("GET /api/dashboard returns summary", async () => {
       const res = await authFetch(`${BASE_URL}/api/dashboard`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
-      expect(typeof data).toBe("object");
+      expect(data).toHaveProperty("documents");
+      expect(typeof data.documents?.total).toBe("number");
     });
 
     test("GET /api/dashboard/activity returns history", async () => {
       const res = await authFetch(`${BASE_URL}/api/dashboard/activity?days=7`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.activity) || typeof data === "object").toBe(true);
     });
 
     test("GET /api/session/stats returns usage", async () => {
       const res = await authFetch(`${BASE_URL}/api/session/stats`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(typeof data).toBe("object");
     });
@@ -216,14 +242,14 @@ describe("HTTP API Integration", () => {
   describe("Threads", () => {
     test("GET /api/threads returns thread list", async () => {
       const res = await authFetch(`${BASE_URL}/api/threads`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.threads)).toBe(true);
     });
 
     test("GET /api/threads with status filter", async () => {
       const res = await authFetch(`${BASE_URL}/api/threads?status=active`);
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(Array.isArray(data.threads)).toBe(true);
     });
@@ -245,7 +271,7 @@ describe("HTTP API Integration", () => {
           project: "test-suite",
         }),
       });
-      expect(res.ok).toBe(true);
+      expect(res.status, `Expected 2xx but got ${res.status}`).toBeLessThan(300);
       const data = await res.json();
       expect(typeof data.id).toBe("string");
       expect(data.id.length).toBeGreaterThan(0);
@@ -254,7 +280,7 @@ describe("HTTP API Integration", () => {
       const searchRes = await authFetch(
         `${BASE_URL}/api/search?q=${encodeURIComponent(pattern)}&type=learning`
       );
-      expect(searchRes.ok).toBe(true);
+      expect(searchRes.status, `Expected 2xx but got ${searchRes.status}`).toBeLessThan(300);
       const searchData = await searchRes.json();
       expect(Array.isArray(searchData.results)).toBe(true);
       // The newly stored document should appear in results

--- a/src/integration/http.test.ts
+++ b/src/integration/http.test.ts
@@ -6,7 +6,30 @@ import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Subprocess } from "bun";
 
 const BASE_URL = "http://localhost:47778";
+
+// Use the real token if already provisioned in the environment; fall back to a
+// fixed test value when the test suite spawns its own fresh server (CI / local
+// dev without oracle-v3 running).  Either way, the spawned server receives the
+// same value via the `env` block in beforeAll, so token and server always agree.
+const TEST_TOKEN = process.env.ORACLE_API_TOKEN ?? "integration-test-token";
+process.env.ORACLE_API_TOKEN = TEST_TOKEN;
+
 let serverProcess: Subprocess | null = null;
+
+/**
+ * All /api/* endpoints except /api/health require Bearer auth (issue #12 Stage 2C).
+ * This helper is a single seam for adding the header — easier to grep and maintain
+ * than sprinkling headers at every call site.
+ */
+async function authFetch(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(url, {
+    ...init,
+    headers: {
+      ...init?.headers,
+      Authorization: `Bearer ${TEST_TOKEN}`,
+    },
+  });
+}
 
 async function waitForServer(maxAttempts = 30): Promise<boolean> {
   for (let i = 0; i < maxAttempts; i++) {
@@ -44,7 +67,7 @@ describe("HTTP API Integration", () => {
       cwd: import.meta.dir.replace("/src/integration", ""),
       stdout: "pipe",
       stderr: "pipe",
-      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: "3000" },
+      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: "3000", ORACLE_API_TOKEN: TEST_TOKEN },
     });
 
     const ready = await waitForServer();
@@ -82,7 +105,7 @@ describe("HTTP API Integration", () => {
     });
 
     test("GET /api/stats returns statistics", async () => {
-      const res = await fetch(`${BASE_URL}/api/stats`);
+      const res = await authFetch(`${BASE_URL}/api/stats`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(typeof data.total).toBe("number");
@@ -95,28 +118,28 @@ describe("HTTP API Integration", () => {
   // ===================
   describe("Search", () => {
     test("GET /api/search with query returns results", async () => {
-      const res = await fetch(`${BASE_URL}/api/search?q=oracle`);
+      const res = await authFetch(`${BASE_URL}/api/search?q=oracle`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     }, 30_000);
 
     test("GET /api/search with type filter", async () => {
-      const res = await fetch(`${BASE_URL}/api/search?q=test&type=learning`);
+      const res = await authFetch(`${BASE_URL}/api/search?q=test&type=learning`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     }, 30_000);
 
     test("GET /api/search with limit and offset", async () => {
-      const res = await fetch(`${BASE_URL}/api/search?q=test&limit=5&offset=0`);
+      const res = await authFetch(`${BASE_URL}/api/search?q=test&limit=5&offset=0`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.results.length).toBeLessThanOrEqual(5);
     }, 30_000);
 
     test("GET /api/search handles empty query", async () => {
-      const res = await fetch(`${BASE_URL}/api/search?q=`);
+      const res = await authFetch(`${BASE_URL}/api/search?q=`);
       // Should return empty or error gracefully
       expect(res.status).toBeLessThan(500);
     }, 30_000);
@@ -127,21 +150,21 @@ describe("HTTP API Integration", () => {
   // ===================
   describe("List & Browse", () => {
     test("GET /api/list returns documents", async () => {
-      const res = await fetch(`${BASE_URL}/api/list`);
+      const res = await authFetch(`${BASE_URL}/api/list`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     });
 
     test("GET /api/list with type filter", async () => {
-      const res = await fetch(`${BASE_URL}/api/list?type=principle`);
+      const res = await authFetch(`${BASE_URL}/api/list?type=principle`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.results)).toBe(true);
     });
 
     test("GET /api/list with pagination", async () => {
-      const res = await fetch(`${BASE_URL}/api/list?limit=10&offset=0`);
+      const res = await authFetch(`${BASE_URL}/api/list?limit=10&offset=0`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(data.results.length).toBeLessThanOrEqual(10);
@@ -153,7 +176,7 @@ describe("HTTP API Integration", () => {
   // ===================
   describe("Reflect", () => {
     test("GET /api/reflect returns response", async () => {
-      const res = await fetch(`${BASE_URL}/api/reflect`);
+      const res = await authFetch(`${BASE_URL}/api/reflect`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       // Empty DB returns { error: "No documents found" }, populated returns { content: ... }
@@ -166,21 +189,21 @@ describe("HTTP API Integration", () => {
   // ===================
   describe("Dashboard", () => {
     test("GET /api/dashboard returns summary", async () => {
-      const res = await fetch(`${BASE_URL}/api/dashboard`);
+      const res = await authFetch(`${BASE_URL}/api/dashboard`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(typeof data).toBe("object");
     });
 
     test("GET /api/dashboard/activity returns history", async () => {
-      const res = await fetch(`${BASE_URL}/api/dashboard/activity?days=7`);
+      const res = await authFetch(`${BASE_URL}/api/dashboard/activity?days=7`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.activity) || typeof data === "object").toBe(true);
     });
 
     test("GET /api/session/stats returns usage", async () => {
-      const res = await fetch(`${BASE_URL}/api/session/stats`);
+      const res = await authFetch(`${BASE_URL}/api/session/stats`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(typeof data).toBe("object");
@@ -192,14 +215,14 @@ describe("HTTP API Integration", () => {
   // ===================
   describe("Threads", () => {
     test("GET /api/threads returns thread list", async () => {
-      const res = await fetch(`${BASE_URL}/api/threads`);
+      const res = await authFetch(`${BASE_URL}/api/threads`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.threads)).toBe(true);
     });
 
     test("GET /api/threads with status filter", async () => {
-      const res = await fetch(`${BASE_URL}/api/threads?status=active`);
+      const res = await authFetch(`${BASE_URL}/api/threads?status=active`);
       expect(res.ok).toBe(true);
       const data = await res.json();
       expect(Array.isArray(data.threads)).toBe(true);
@@ -212,7 +235,7 @@ describe("HTTP API Integration", () => {
   describe("Knowledge Ingestion", () => {
     test("POST /api/learn persists a pattern and returns an id", async () => {
       const pattern = `integration-test-pattern-${Date.now()}`;
-      const res = await fetch(`${BASE_URL}/api/learn`, {
+      const res = await authFetch(`${BASE_URL}/api/learn`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -228,7 +251,7 @@ describe("HTTP API Integration", () => {
       expect(data.id.length).toBeGreaterThan(0);
 
       // Verify persistence: search for the pattern we just stored
-      const searchRes = await fetch(
+      const searchRes = await authFetch(
         `${BASE_URL}/api/search?q=${encodeURIComponent(pattern)}&type=learning`
       );
       expect(searchRes.ok).toBe(true);
@@ -240,7 +263,7 @@ describe("HTTP API Integration", () => {
     }, 30_000);
 
     test("POST /api/learn rejects missing pattern field", async () => {
-      const res = await fetch(`${BASE_URL}/api/learn`, {
+      const res = await authFetch(`${BASE_URL}/api/learn`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ source: "test" }),
@@ -256,13 +279,13 @@ describe("HTTP API Integration", () => {
   // ===================
   describe("Error Handling", () => {
     test("Invalid endpoint returns 404", async () => {
-      const res = await fetch(`${BASE_URL}/api/nonexistent`);
+      const res = await authFetch(`${BASE_URL}/api/nonexistent`);
       // Should be 404 or serve SPA
       expect(res.status).toBeLessThan(500);
     });
 
     test("GET /api/file without path returns error", async () => {
-      const res = await fetch(`${BASE_URL}/api/file`);
+      const res = await authFetch(`${BASE_URL}/api/file`);
       expect(res.status).toBeGreaterThanOrEqual(400);
     });
   });


### PR DESCRIPTION
## Summary

- Adds `authFetch()` helper — single seam for `Authorization: Bearer` header (Option B from issue)
- `TEST_TOKEN` reads from `process.env.ORACLE_API_TOKEN`, falling back to `'integration-test-token'` when running fresh in CI
- Passes `ORACLE_API_TOKEN` into the spawned server env so token always matches requests
- Replaces all 17 non-`/api/health` `fetch()` call sites with `authFetch()`
- `/api/health` remains bare `fetch()` — it's always auth-exempt per middleware design

## Root cause

`#12` Stage 2C (PR #19) flipped `/api/*` to required-enforce Bearer auth. The integration test suite was not updated to send the `Authorization` header, causing all endpoints except `/api/health` to return 401.

## Test plan

- [x] `bun test:unit` — 157 pass, 0 fail (unchanged)
- [x] `bun test src/integration/http.test.ts` — 19 pass, 0 fail (was 4 pass / 15 fail)
- [x] `/api/health` still works without auth (exempt by design)
- [x] Works with existing running server (`ORACLE_API_TOKEN` from env) and with test-spawned server (fallback token)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)