### PR TITLE
fix: Qdrant search retry on transient errors + improved error logging

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -183,8 +183,10 @@ export async function handleSearch(
       if (result.status === 'fulfilled') {
         vectorResults.push(...result.value);
       } else {
-        const msg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-        console.error('[Vector Search Error]', msg);
+        const err = result.reason;
+        const msg = err instanceof Error ? err.message : String(err);
+        const stack = err instanceof Error && err.stack ? `\n  ${err.stack.split('\n').slice(1, 3).join('\n  ')}` : '';
+        console.error(`[Vector Search Error] ${msg}${stack}`);
         if (!warning) warning = `Vector search error: ${msg}`;
       }
     }

--- a/src/vector/adapters/qdrant.ts
+++ b/src/vector/adapters/qdrant.ts
@@ -92,6 +92,30 @@ export class QdrantAdapter implements VectorStoreAdapter {
     console.log(`[Qdrant] Added ${docs.length} documents`);
   }
 
+  private static readonly RETRY_DELAY_MS = 500;
+
+  /**
+   * Search with a single retry on transient errors (network blips, Qdrant Cloud 400/5xx).
+   * Used by both query() and queryById() to ensure consistent resilience.
+   */
+  private async searchWithRetry(params: Record<string, any>): Promise<any[]> {
+    try {
+      return await this.client.search(this.collectionName, params);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[Qdrant] Search failed (attempt 1/2): ${msg} — retrying in ${QdrantAdapter.RETRY_DELAY_MS}ms`);
+      await new Promise(r => setTimeout(r, QdrantAdapter.RETRY_DELAY_MS));
+      try {
+        const results = await this.client.search(this.collectionName, params);
+        console.log('[Qdrant] Search retry succeeded');
+        return results;
+      } catch (retryErr: unknown) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        throw new Error(`Qdrant search failed after retry: ${retryMsg}`, { cause: retryErr });
+      }
+    }
+  }
+
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
     if (!this.client) throw new Error('Qdrant not connected');
 
@@ -104,29 +128,12 @@ export class QdrantAdapter implements VectorStoreAdapter {
       })),
     } : undefined;
 
-    const searchParams = {
+    const results = await this.searchWithRetry({
       vector: queryEmbedding,
       limit,
       with_payload: true,
       ...(filter && { filter }),
-    };
-
-    // Retry once on transient errors (network blips, Qdrant Cloud 400/5xx)
-    let results: any[];
-    try {
-      results = await this.client.search(this.collectionName, searchParams);
-    } catch (err: any) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[Qdrant] Search failed (attempt 1/2): ${msg} — retrying in 500ms`);
-      await new Promise(r => setTimeout(r, 500));
-      try {
-        results = await this.client.search(this.collectionName, searchParams);
-        console.log('[Qdrant] Search retry succeeded');
-      } catch (retryErr: any) {
-        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-        throw new Error(`Qdrant search failed after retry: ${retryMsg}`);
-      }
-    }
+    });
 
     return {
       ids: results.map((r: any) => r.payload._id || String(r.id)),
@@ -155,7 +162,7 @@ export class QdrantAdapter implements VectorStoreAdapter {
     }
 
     const vector = points[0].vector;
-    const results = await this.client.search(this.collectionName, {
+    const results = await this.searchWithRetry({
       vector,
       limit: nResults + 1,
       with_payload: true,

--- a/src/vector/adapters/qdrant.ts
+++ b/src/vector/adapters/qdrant.ts
@@ -104,12 +104,29 @@ export class QdrantAdapter implements VectorStoreAdapter {
       })),
     } : undefined;
 
-    const results = await this.client.search(this.collectionName, {
+    const searchParams = {
       vector: queryEmbedding,
       limit,
       with_payload: true,
       ...(filter && { filter }),
-    });
+    };
+
+    // Retry once on transient errors (network blips, Qdrant Cloud 400/5xx)
+    let results: any[];
+    try {
+      results = await this.client.search(this.collectionName, searchParams);
+    } catch (err: any) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[Qdrant] Search failed (attempt 1/2): ${msg} — retrying in 500ms`);
+      await new Promise(r => setTimeout(r, 500));
+      try {
+        results = await this.client.search(this.collectionName, searchParams);
+        console.log('[Qdrant] Search retry succeeded');
+      } catch (retryErr: any) {
+        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+        throw new Error(`Qdrant search failed after retry: ${retryMsg}`);
+      }
+    }
 
     return {
       ids: results.map((r: any) => r.payload._id || String(r.id)),


### PR DESCRIPTION
## Summary
- Add retry-once (500ms delay) in `QdrantAdapter.query()` for transient Qdrant Cloud errors
- Improve Vector Search Error logging with partial stack trace for easier debugging

## Context
Part of W17 MCP resilience effort. Oracle v3 had 0.3% vector search error rate (2/598 searches) from transient Qdrant Cloud blips. This caused `[Vector Search Error] Bad Request` without retry or useful diagnostics.

## Test plan
- [x] Unit tests pass (25 pass, 2 pre-existing failures in ChromaMCP — unrelated)
- [x] Direct Qdrant search verified working (1536-dim collection, 164 points)
- [ ] Monitor error rate after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)