### PR TITLE
fix(#29): review fixes — 7 issues from multi-agent review

### DIFF
--- a/src/cli/commands/vault.ts
+++ b/src/cli/commands/vault.ts
@@ -116,12 +116,18 @@ export function registerVault(program: Command): void {
         `--batch-size=${opts.batchSize}`,
         `--model=${opts.model}`,
       ];
-      const proc = Bun.spawn(
-        ['bun', path.join(import.meta.dirname || __dirname, '..', '..', '..', 'scripts', 'backfill-vector.ts'), ...scriptArgs],
-        { stdout: 'inherit', stderr: 'inherit', env: process.env },
-      );
+      let proc: ReturnType<typeof Bun.spawn>;
+      try {
+        proc = Bun.spawn(
+          ['bun', path.join(import.meta.dirname || __dirname, '..', '..', '..', 'scripts', 'backfill-vector.ts'), ...scriptArgs],
+          { stdout: 'inherit', stderr: 'inherit', env: process.env },
+        );
+      } catch (err) {
+        console.error(`[vault] Failed to spawn backfill script: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
       const code = await proc.exited;
-      process.exit(code);
+      process.exit(code ?? 1);
     });
 
   // Default action: status

--- a/src/routes/knowledge.ts
+++ b/src/routes/knowledge.ts
@@ -33,27 +33,35 @@ export function registerKnowledgeRoutes(app: Hono) {
       let vectorStore = null;
       try {
         vectorStore = await ensureVectorStoreConnected();
-      } catch { /* vector unavailable — proceed without */ }
+      } catch (err) {
+        console.error('[knowledge] Vector store connection failed:', err instanceof Error ? err.message : String(err));
+      }
 
-      const concepts = coerceConcepts(data.concepts);
-      const filePath = path.isAbsolute(result.file)
-        ? result.file
-        : path.join(REPO_ROOT, result.file);
-      const content = fs.readFileSync(filePath, 'utf-8').replace(/^---[\s\S]*?---\n*/, '');
+      let content: string;
+      try {
+        const concepts = coerceConcepts(data.concepts);
+        const filePath = path.isAbsolute(result.file)
+          ? result.file
+          : path.join(REPO_ROOT, result.file);
+        content = fs.readFileSync(filePath, 'utf-8').replace(/^---[\s\S]*?---\n*/, '');
 
-      const vectorResult = await syncLearnToVector(
-        vectorStore,
-        vectorStore ? 'connected' : 'unavailable',
-        result,
-        content,
-        concepts,
-      );
+        const vectorResult = await syncLearnToVector(
+          vectorStore,
+          vectorStore ? 'connected' : 'unavailable',
+          result,
+          content,
+          concepts,
+        );
 
-      return c.json({
-        ...result,
-        vector_synced: vectorResult.synced,
-        ...(vectorResult.error ? { vector_error: vectorResult.error } : {}),
-      });
+        return c.json({
+          ...result,
+          vector_synced: vectorResult.synced,
+          ...(vectorResult.error ? { vector_error: 'vector sync failed' } : {}),
+        });
+      } catch (readErr) {
+        console.error(`[knowledge] Content read failed for ${result.id}:`, readErr instanceof Error ? readErr.message : String(readErr));
+        return c.json({ ...result, vector_synced: false, vector_error: 'content read failed' });
+      }
     } catch (error) {
       return c.json({
         error: error instanceof Error ? error.message : 'Unknown error'

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -264,7 +264,7 @@ export function createLearning(deps: LearnDeps, input: LearnInput): LearnResult 
       project: project || null,
     }).run();
   } catch (e) {
-    console.error('Failed to log learning:', e);
+    console.error(`[learn] Failed to write learnLog for ${id}:`, e instanceof Error ? e.message : String(e));
   }
 
   return {
@@ -289,8 +289,8 @@ export async function syncLearnToVector(
   content: string,
   concepts: string[],
 ): Promise<{ synced: boolean; error?: string }> {
-  if (!vectorStore || vectorStatus === 'unavailable') {
-    return { synced: false, error: 'vector store unavailable' };
+  if (!vectorStore || vectorStatus !== 'connected') {
+    return { synced: false, error: `vector store not ready (status: ${vectorStatus ?? 'null'})` };
   }
 
   const doc = {
@@ -303,23 +303,22 @@ export async function syncLearnToVector(
     },
   };
 
-  for (let attempt = 0; attempt <= VECTOR_RETRY_DELAYS.length; attempt++) {
+  let lastError = '';
+  for (let attempt = 0; attempt < VECTOR_RETRY_DELAYS.length + 1; attempt++) {
     try {
       await vectorStore.addDocuments([doc]);
       console.log(`[learn] Vector sync OK: ${result.id}`);
       return { synced: true };
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
+      lastError = error instanceof Error ? error.message : String(error);
       if (attempt < VECTOR_RETRY_DELAYS.length) {
-        console.warn(`[learn] Vector write attempt ${attempt + 1} failed: ${msg} — retrying in ${VECTOR_RETRY_DELAYS[attempt]}ms`);
+        console.warn(`[learn] Vector write attempt ${attempt + 1} failed: ${lastError} — retrying in ${VECTOR_RETRY_DELAYS[attempt]}ms`);
         await new Promise(r => setTimeout(r, VECTOR_RETRY_DELAYS[attempt]));
-      } else {
-        console.error(`[learn] Vector write failed after ${attempt + 1} attempts: ${msg}`);
-        return { synced: false, error: msg };
       }
     }
   }
-  return { synced: false, error: 'exhausted retries' };
+  console.error(`[learn] Vector write failed after ${VECTOR_RETRY_DELAYS.length + 1} attempts: ${lastError}`);
+  return { synced: false, error: lastError };
 }
 
 // ============================================================================
@@ -332,14 +331,26 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     input,
   );
 
-  const concepts = coerceConcepts(input.concepts);
-  const content = fs.readFileSync(
-    path.isAbsolute(result.file)
-      ? result.file
-      : path.join(ctx.repoRoot, result.file),
-    'utf-8',
-  ).replace(/^---[\s\S]*?---\n*/, '');
+  let content: string;
+  try {
+    content = fs.readFileSync(
+      path.isAbsolute(result.file)
+        ? result.file
+        : path.join(ctx.repoRoot, result.file),
+      'utf-8',
+    ).replace(/^---[\s\S]*?---\n*/, '');
+  } catch (readErr) {
+    const msg = readErr instanceof Error ? readErr.message : String(readErr);
+    console.error(`[learn] sqlite write OK (id=${result.id}) but content read failed: ${msg}`);
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({ ...result, vector_synced: false, vector_error: `content_read_failed: ${msg}` }, null, 2)
+      }]
+    };
+  }
 
+  const concepts = coerceConcepts(input.concepts);
   const vectorResult = await syncLearnToVector(
     ctx.vectorStore,
     ctx.vectorStatus,


### PR DESCRIPTION
## Summary

Follow-up to PR #30 — the review fix commit missed the squash merge. These are the 7 fixes from the 3-agent parallel review (code-reviewer, security-reviewer, silent-failure-hunter).

- **[Critical]** `knowledge.ts`: log vector connection errors (was empty catch — exact same anti-pattern as the original #29 bug)
- **[Critical]** `learn.ts`: guard `vectorStatus !== 'connected'` instead of `=== 'unavailable'` (startup race → 21s retry storm)
- **[High]** `learn.ts` + `knowledge.ts`: wrap `readFileSync` in try/catch after sqlite commit (partial-write protection)
- **[High]** `vault.ts`: handle `Bun.spawn` failure + signal-kill `null → 1`
- **[High]** `learn.ts`: structured error context in learnLog catch
- **[Medium]** `knowledge.ts`: sanitize `vector_error` in HTTP response (was leaking internals)
- **[Low]** `learn.ts`: remove dead unreachable return, restructure retry loop

## Test plan

- [x] `bun run build` — 0 new type errors
- [x] `bun test` — 116 pass, 0 fail
- [x] Review artifact: `.prp-output/reviews/pr-30-agents-review.md`

Fixes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)