### PR TITLE
fix: intercept GET /mcp probe to prevent 10s hang

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -155,6 +155,21 @@ app.use('/mcp', cors({
   exposeHeaders: ['mcp-session-id', 'mcp-protocol-version'],
 }));
 
+// GET /mcp probe interceptor — mcp-remote OAuth discovery sends GET without
+// MCP headers; the SDK's handler would open a never-closing SSE stream causing
+// a 10s hang. Return quick JSON instead. Pass through with next() when MCP
+// headers are present (legitimate SSE client). See gobikom/arra-oracle-v3#40.
+app.get('/mcp', async (c, next) => {
+  const hasLastEventId = c.req.header('Last-Event-ID');
+  const hasSessionId = c.req.header('mcp-session-id');
+
+  if (!hasLastEventId && !hasSessionId) {
+    return c.json({ status: 'ok', transport: 'streamable-http' }, 200);
+  }
+
+  return next();
+});
+
 // MCP Streamable HTTP endpoint — Bearer token auth (OAuth or static), stateless per-request
 app.all('/mcp', async (c) => {
   // Require at least one auth method to be configured


### PR DESCRIPTION
## Summary

- Add `app.get('/mcp')` middleware before `app.all('/mcp')` to intercept OAuth discovery probes
- Probe requests (no `Last-Event-ID` or `mcp-session-id` headers) get instant JSON response instead of hanging on never-closing SSE stream
- Legitimate MCP SSE clients with proper headers pass through via `next()` unchanged

## Problem

`mcp-remote` (Claude Code's MCP HTTP proxy) sends a GET probe to `/mcp` without MCP headers during OAuth discovery. The SDK's handler opens an SSE stream that never closes, causing a 10s hang. Claude Code's `/mcp` reconnect timeout is shorter, so it reports failure.

## Testing

- `bun run build` — type check passes
- `bun run test:unit` — 153 tests pass, 0 fail
- Manual: `curl -s http://localhost:47778/mcp` → instant JSON (not 10s hang)

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)