### PR TITLE
feat: add wiki/systems/services.md — OpenClaw service inventory

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -2,8 +2,8 @@
 title: Wiki Index
 type: wiki
 status: active
-updated: 2026-05-09
-total_pages: 4
+updated: 2026-05-26
+total_pages: 5
 ---
 
 # Oracle Wiki
@@ -21,7 +21,9 @@ Structured knowledge pages synthesized from Oracle entries. Each page compiles a
 
 ## Systems
 
-_(Future: infrastructure pages — safe-merge, systemd services, nginx, etc.)_
+| Page | Updated | Summary |
+|------|---------|---------|
+| [services](systems/services.md) | 2026-05-26 | OpenClaw VPS services — ports, paths, status, access methods |
 
 ## Patterns
 

--- a/wiki/systems/services.md
+++ b/wiki/systems/services.md
@@ -1,0 +1,66 @@
+---
+title: OpenClaw Services
+type: wiki
+status: active
+updated: 2026-05-26
+tags: [wiki, services, infrastructure]
+---
+
+# OpenClaw Services
+
+## Core Services
+
+| Service | Port | Path | Status |
+|---------|------|------|--------|
+| **openclaw** | 18789 | `/usr/bin/openclaw` | Active |
+| **openclaw-gateway** | 18789/18791/18792 | user systemd | Active |
+| **nginx** | 80/443 | system systemd — reverse proxy | Active |
+
+## Memory & Knowledge
+
+| Service | Port | Path | Status |
+|---------|------|------|--------|
+| **psak-soul-mcp** | 8000 | `~/repos/memory/my-ai-soul-mcp` | Active |
+| **oracle-v3** | 47778 | `~/repos/memory/arra-oracle-v3` — MCP via `mysoul.goko.digital/oracle-mcp` | Active |
+
+## Agent Infrastructure
+
+| Service | Port | Path | Status |
+|---------|------|------|--------|
+| **soul-orchestra** | — | `~/repos/agents/soul-orchestra` — 10 scores on cron | Active |
+| **soul-orchestra-dashboard** | 8086 | https://orchestra.goko.digital (basic auth) | Active |
+| **tmux-dash** | 8088 | https://tmux-dash.goko.digital (basic auth) | Active |
+| **claude-telegram-bot** | — | systemd user service, Restart=always | Active |
+| **dora-telegram-bot** | — | `~/repos/bots/cat-dance-teacher` | Active |
+
+## Web Terminals
+
+| Service | Port | Path | Status |
+|---------|------|------|--------|
+| **ttyd** | 7681 | user systemd — web terminal | Active |
+| **codewebway** | 8090 | `~/CodeWebway` | Active |
+
+## Observability
+
+| Service | Scope | Status |
+|---------|-------|--------|
+| **Sentry** | clienta.ai API + Web | Active |
+| **Grafana Cloud** | App metrics (15s) + VPS metrics (60s) | Active |
+| **Grafana Alerts** | 7 VPS + 4 App rules → Telegram | Active |
+| **Grafana Alloy** | VPS resource metrics push 60s | Active |
+| **UptimeRobot** | 5 monitors (api/web/landing) | Active |
+| **auto-ops** | 31 services health check | Active |
+| **infra-health-check** | Sentry + Grafana + UptimeRobot (4h) | Active |
+
+## Trading & Automation
+
+| Service | Port | Path | Status |
+|---------|------|------|--------|
+| **tv-webhook-settrade** | 8700 | `~/tv-webhook-settrade` | Active |
+| **sniper-options** | — | `~/repos/trading/sniper-s50` | Inactive |
+
+## Access Methods
+
+1. **SSH Direct**: `ssh -i id_ed25519 openclaw@103.245.164.27`
+2. **SSH via Root**: `ssh -i id_ed25519 root@103.245.164.27` then `su - openclaw`
+3. **CodeWebway**: `http://103.245.164.27:8090`


### PR DESCRIPTION
## Summary

Phase 2 of agent-devops#336: extend Oracle wiki with `systems/` tier.

- Create `wiki/systems/services.md` — categorized service table (core, memory, agent infra, web terminals, observability, trading)
- Update `wiki/index.md` — add Systems section, bump total_pages to 5

This is the Tier 3 of the wiki-driven CLAUDE.md architecture. ~/CLAUDE.md can reference this page instead of inlining duplicate service tables.

## Test plan

- [x] Wiki page follows existing frontmatter format
- [x] Index updated with correct link

Ref: gobikom/agent-devops#336

🤖 Generated with [Claude Code](https://claude.com/claude-code)