### PR TITLE
docs: add PRP optimization note to wiki log

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -15,3 +15,4 @@ Append-only record of wiki page updates.
 | 2026-05-24 | updated | projects/auto-ops.md | +1 learning: swap/memory monitoring via /proc/meminfo (PR #39) |
 | 2026-05-26 | created | systems/services.md | OpenClaw VPS service inventory — ports, paths, status |
 | 2026-05-27 | updated | projects/soul-orchestra.md | +wiki_ref lazy-loading pattern, conductor/wiki/ in architecture tree |
+| 2026-05-27 | note | — | PRP token optimization tools merged (prp-framework#96). 4 tools: prp-explore, prp-validate, prp-diff, prp-state. Tracking via agent-devops#340 |


### PR DESCRIPTION
Track PRP token optimization tools (prp-framework#96) in wiki log. Ref: agent-devops#340.