### PR TITLE
fix: retry Qdrant vector writes with exponential backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@qdrant/js-client-rest": "^1.17.0",
+    "@qdrant/js-client-rest": "~1.17.0",
     "commander": "^14.0.3",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.14",

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -95,26 +95,48 @@ export async function storeDocuments(
   }
 
   const BATCH_SIZE = 100;
+  const MAX_RETRIES = 3;
+  const RETRY_BASE_MS = 500;
   let vectorSuccess = true;
+  const failedBatches: { batchIndex: number; docIds: string[]; error: string }[] = [];
 
   for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    const batchIndex = Math.floor(i / BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(ids.length / BATCH_SIZE);
     const batchIds = ids.slice(i, i + BATCH_SIZE);
     const batchContents = contents.slice(i, i + BATCH_SIZE);
     const batchMetadatas = metadatas.slice(i, i + BATCH_SIZE);
 
-    try {
-      const vectorDocs = batchIds.map((id, idx) => ({
-        id,
-        document: batchContents[idx],
-        metadata: batchMetadatas[idx]
-      }));
-      await vectorClient.addDocuments(vectorDocs);
-      console.log(`Vector batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(ids.length / BATCH_SIZE)} stored`);
-    } catch (error) {
-      console.error(`Vector batch failed:`, error);
-      vectorSuccess = false;
+    const vectorDocs = batchIds.map((id, idx) => ({
+      id,
+      document: batchContents[idx],
+      metadata: batchMetadatas[idx]
+    }));
+
+    let succeeded = false;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        await vectorClient.addDocuments(vectorDocs);
+        console.log(`Vector batch ${batchIndex}/${totalBatches} stored`);
+        succeeded = true;
+        break;
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        if (attempt < MAX_RETRIES) {
+          const delayMs = RETRY_BASE_MS * Math.pow(2, attempt - 1);
+          console.warn(`Vector batch ${batchIndex}/${totalBatches} failed (attempt ${attempt}/${MAX_RETRIES}): ${errMsg} — retrying in ${delayMs}ms`);
+          await new Promise(r => setTimeout(r, delayMs));
+        } else {
+          console.error(`Vector batch ${batchIndex}/${totalBatches} FAILED after ${MAX_RETRIES} attempts: ${errMsg} [${batchIds.length} docs: ${batchIds[0]}..${batchIds[batchIds.length - 1]}]`);
+          failedBatches.push({ batchIndex, docIds: batchIds, error: errMsg });
+          vectorSuccess = false;
+        }
+      }
     }
   }
 
-  console.log(`Stored in SQLite${vectorSuccess ? ` + ${vectorClient.name}` : ` (${vectorClient.name} failed)`}`);
+  if (failedBatches.length > 0) {
+    console.error(`Vector drift: ${failedBatches.reduce((n, b) => n + b.docIds.length, 0)} docs in SQLite but NOT in ${vectorClient.name}. Weekly backfill cron will catch up, or run: bun scripts/backfill-vector.ts`);
+  }
+  console.log(`Stored in SQLite${vectorSuccess ? ` + ${vectorClient.name}` : ` (${vectorClient.name} failed — ${failedBatches.length} batch(es))`}`);
 }

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -113,12 +113,10 @@ export async function storeDocuments(
       metadata: batchMetadatas[idx]
     }));
 
-    let succeeded = false;
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
         await vectorClient.addDocuments(vectorDocs);
         console.log(`Vector batch ${batchIndex}/${totalBatches} stored`);
-        succeeded = true;
         break;
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- Add 3x retry with exponential backoff (500ms→1s→2s) to Qdrant batch writes in `storage.ts`
- Log structured error on final failure: batch index, doc count, first/last doc ID
- Pin `@qdrant/js-client-rest` to `~1.17.0` (prevent auto-upgrade past server 1.16.3 compat window)

## Root Cause
`storage.ts:113` caught Qdrant errors and continued — SQLite already committed, causing silent drift. 1,891 learnings (W12-W17) existed in SQLite but not Qdrant, blocking evolution metrics (agent-devops#29 Phase 4).

## Test plan
- [x] `tsc --noEmit` passes
- [x] Backfill already synced all 6,749 docs (verified 0 failed)
- [ ] Simulate Qdrant failure → verify retry + structured error log

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)